### PR TITLE
if the server url isn't passed in the parameters, look in config, to see if you can find it.

### DIFF
--- a/uSync.Commands.Core/Commands/SyncCommandBase.cs
+++ b/uSync.Commands.Core/Commands/SyncCommandBase.cs
@@ -63,7 +63,11 @@ public abstract class SyncCommandBase
     private Uri? GetServerUriFromConfig(string configPath)
     {
         var urlString = Configuration[configPath];
-        if (urlString is not null) return new Uri(urlString);
+        if (string.IsNullOrWhiteSpace(urlString)) return null;
+
+        if (Uri.TryCreate(urlString, UriKind.Absolute, out var uri))
+            return uri;
+
         return null;
     }
 
@@ -79,9 +83,13 @@ public abstract class SyncCommandBase
             umbracoElement.TryGetProperty("applicationUrl", out var applicationUrlElement))
         {
             var urlString = applicationUrlElement.GetString();
-            if (urlString is not null)
-                return new Uri(urlString.Split(';')[0]);
+
+            if (string.IsNullOrWhiteSpace(urlString)) return null;
+
+            if (Uri.TryCreate(urlString.Split(';')[0], UriKind.Absolute, out var uri))
+                return uri;
         }
+
         return null;
     }
 }

--- a/uSync.Commands.Core/Commands/SyncCommandBase.cs
+++ b/uSync.Commands.Core/Commands/SyncCommandBase.cs
@@ -2,6 +2,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text.Json;
 
 namespace uSync.Commands.Core.Commands;
 
@@ -27,14 +28,57 @@ public abstract class SyncCommandBase
         command.AddOption(optionClientId);
     }
 
-    public SyncConnectionParameters GetConnectionPartameters(InvocationContext context) 
+    public SyncConnectionParameters GetConnectionPartameters(InvocationContext context)
     {
         return new SyncConnectionParameters
         {
-            Url = context.ParseResult?.GetValueForOption(optionServerUrl) ?? throw new Exception("No host"),
+            Url = GetServerUri(context) ?? throw new Exception("No host"),
             ClientSecret = context.ParseResult?.GetValueForOption(optionSecret) ?? Configuration["uSync:Command:Secret"] ?? throw new Exception("No Client Secret"),
             ClientId = context.ParseResult?.GetValueForOption(optionClientId) ?? Configuration["uSync:Command:ClientId"] ?? throw new Exception("No ClientId")
-        };    
+        };
+    }
+
+    private Uri? GetServerUri(InvocationContext context)
+    {
+        var uri = context.ParseResult?.GetValueForOption(optionServerUrl);
+        if (uri is not null) return uri;
+
+        uri = GetServerUriFromConfig("uSync:Command:ServerUrl");
+        if (uri is not null) return uri;
+
+        uri = GetServerUriFromConfig("Umbraco:CMS:WebRouting:UmbracoApplicationUrl");
+        if (uri is not null) return uri;
+
+        uri = GetServerUrlFromLaunchSettings("Properties/launchSettings.json");
+        if (uri is not null) return uri;
+
+#if DEBUG
+        uri = GetServerUrlFromLaunchSettings("../Umbraco.Site/Properties/launchSettings.json");
+        if (uri is not null) return uri;
+#endif
+
+        return null;
+    }
+
+    private Uri? GetServerUriFromConfig(string configPath)
+    {
+        var urlString = Configuration[configPath];
+        if (urlString is not null) return new Uri(urlString);
+        return null;
+    }
+
+    private Uri? GetServerUrlFromLaunchSettings(string filePath)
+    {
+        var fullPath = Path.Combine(Directory.GetCurrentDirectory(), filePath);
+        if (!File.Exists(fullPath)) return null;
+
+        var json = File.ReadAllText(fullPath);
+        var doc = JsonDocument.Parse(json);
+        var urlString = doc.RootElement.GetProperty("profiles").GetProperty("Umbraco.Web.UI").GetProperty("applicationUrl").GetString();
+        if (urlString is not null) 
+            return new Uri(urlString.Split(';')[0]);
+        
+        return null;
     }
 }
 

--- a/uSync.Commands.Core/Commands/SyncCommandBase.cs
+++ b/uSync.Commands.Core/Commands/SyncCommandBase.cs
@@ -74,10 +74,14 @@ public abstract class SyncCommandBase
 
         var json = File.ReadAllText(fullPath);
         var doc = JsonDocument.Parse(json);
-        var urlString = doc.RootElement.GetProperty("profiles").GetProperty("Umbraco.Web.UI").GetProperty("applicationUrl").GetString();
-        if (urlString is not null) 
-            return new Uri(urlString.Split(';')[0]);
-        
+        if (doc.RootElement.TryGetProperty("profiles", out var profilesElement) &&
+            profilesElement.TryGetProperty("Umbraco.Web.UI", out var umbracoElement) &&
+            umbracoElement.TryGetProperty("applicationUrl", out var applicationUrlElement))
+        {
+            var urlString = applicationUrlElement.GetString();
+            if (urlString is not null)
+                return new Uri(urlString.Split(';')[0]);
+        }
         return null;
     }
 }


### PR DESCRIPTION
If the server url isn't passed as part of the command line (e.g -s https://myserver.com). 

then this code will look in the appssettings. 

 - uSync:Command:ServerUrl
 - Umbraco:CMS:WebRouting:UmbracoApplicationUrl

it will then check for a launchSettings.json file. in properties/launchSettings.json. 

this means if you run the usyncCli command inside the directory the site is running in it should be able to hunt out the url it's running on without you having to pass it on the command line

